### PR TITLE
Fixed left-aligned numbers on several pages

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -818,6 +818,10 @@ header {
   display: block;
 }
 
+td:has(> span.basictext):nth-child(2) {
+  text-align: right;
+}
+
 
 @keyframes fadeColor {
   0% {
@@ -861,7 +865,7 @@ header {
     display: inline-block;
     border: solid 2px;
     width: 22.5%
-  
+
 }
 
 .selectorspan {


### PR DESCRIPTION
This pull request fixes left-aligned percentages on the [Hub](https://adjectils.com/hub.html), [Spider's Den](https://adjectils.com/spider.html), [The End](https://adjectils.com/end.html), and [Rift](https://adjectils.com/rift.html) pages with one CSS rule.